### PR TITLE
Remove explicit bson_ext dependency

### DIFF
--- a/mongoid-simple-tags.gemspec
+++ b/mongoid-simple-tags.gemspec
@@ -18,5 +18,4 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.add_development_dependency "rspec", "~> 2.10.0"
   s.add_dependency "mongoid", "~> 3.0.3"
-  s.add_dependency "bson_ext", "~> 1.6"
 end


### PR DESCRIPTION
The explicit dependency on bson_ext prevents this gem from working with jruby. Mongoid now handles this dependency more gracefully on its own, hooking into bson_ext when support for C extensions is available and using a jruby-compatible equivalent when necessary. Feel free to merge or not as you see fit. Thanks!
