### PR TITLE
Added support for all-criteria

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -24,14 +24,21 @@ mongoid-simple-tags is a basic and simple tagging system for mongoid using map-r
 
   u.tags     # => ["linux","tucuman","free software"]
 
-  User.tagged_with("linux") # => u
-  User.tagged_with(["tucuman", "free software"]) # => u
+  User.tagged_with("linux") # => [u]
+  User.tagged_with(["tucuman", "free software"]) # => [u]
+  User.tagged_with(["linux", "foo"]) # => [u]
+
+  User.tagged_with_all(["linux"]) # => [u]
+  User.tagged_with_all(["linux", "foo"]) # => []
 
   u2 = User.new(:name => "ubuntu")
   u2.tag_list = "linux"
   u2.save
 
   User.tagged_with("linux") # => [u, u2]
+  User.tagged_with(["linux", "tucuman"]) # => [u, u2]
+
+  User.tagged_with_all(["linux", "tucuman"]) # => [u]
 
   # using map-reduce function
 

--- a/lib/mongoid-simple-tags.rb
+++ b/lib/mongoid-simple-tags.rb
@@ -67,9 +67,15 @@ module Mongoid
           criteria.in(:tags => tags)
         end
 
+        def tagged_with_all(tags)
+          tags = [tags] unless tags.is_a? Array
+          criteria.all(:tags => tags)
+        end
+
         def tag_list
           self.all_tags.collect{|tag| tag[:name]}
         end
+
       end
 
     end

--- a/spec/mongoid-simple-tags_spec.rb
+++ b/spec/mongoid-simple-tags_spec.rb
@@ -80,6 +80,15 @@ describe "A Taggable model with tags assigned" do
     User.tag_list.sort.should == ["linux", "tucuman", "free software"].sort
   end
 
+  it 'should be able to find tagged_with_all objects' do
+    user_2 = User.create! name: 'Jane Doe', tag_list: 'linux, foo, bar'
+
+    User.tagged_with_all(%w[foo linux]).should == [user_2]
+    User.tagged_with_all('linux').should =~ [@user, user_2]
+    User.tagged_with_all(%w[linux]).should =~ [@user, user_2]
+    User.tagged_with_all([]).should == []
+    User.tagged_with_all(%w[foo tucuman]).should == []
+  end
 end
 
 describe "A Taggable model with scope" do


### PR DESCRIPTION
This commit adds support for the MongoDB $all selector, which requires all submitted tags to be present on the model.
