### PR TITLE
Support for Mongoid >= 3.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,33 +1,29 @@
 PATH
   remote: .
   specs:
-    mongoid-simple-tags (0.0.7)
-      bson_ext (~> 1.6)
-      mongoid (~> 3.0.3)
+    mongoid-simple-tags (0.0.9)
+      mongoid (>= 3.0.3)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    activemodel (3.2.8)
-      activesupport (= 3.2.8)
+    activemodel (3.2.12)
+      activesupport (= 3.2.12)
       builder (~> 3.0.0)
-    activesupport (3.2.8)
+    activesupport (3.2.12)
       i18n (~> 0.6)
       multi_json (~> 1.0)
-    bson (1.7.0)
-    bson_ext (1.7.0)
-      bson (~> 1.7.0)
-    builder (3.0.3)
+    builder (3.0.4)
     diff-lcs (1.1.3)
     i18n (0.6.1)
-    mongoid (3.0.5)
-      activemodel (~> 3.1)
-      moped (~> 1.1)
+    mongoid (3.1.0)
+      activemodel (~> 3.2)
+      moped (~> 1.4.2)
       origin (~> 1.0)
       tzinfo (~> 0.3.22)
-    moped (1.2.1)
-    multi_json (1.3.6)
-    origin (1.0.8)
+    moped (1.4.2)
+    multi_json (1.6.1)
+    origin (1.0.11)
     rspec (2.10.0)
       rspec-core (~> 2.10.0)
       rspec-expectations (~> 2.10.0)
@@ -36,7 +32,7 @@ GEM
     rspec-expectations (2.10.0)
       diff-lcs (~> 1.1.3)
     rspec-mocks (2.10.1)
-    tzinfo (0.3.33)
+    tzinfo (0.3.35)
 
 PLATFORMS
   ruby

--- a/mongoid-simple-tags.gemspec
+++ b/mongoid-simple-tags.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
   s.add_development_dependency "rspec", "~> 2.10.0"
-  s.add_dependency "mongoid", "~> 3.0.3"
+  s.add_dependency "mongoid", ">= 3.0.3"
 end


### PR DESCRIPTION
Updated the gemspec to allow Mongoid 3.1. All specs pass, and I've verified it works in my own applications.
