### PR TITLE
bug fix - returns an empty array even if tag_list is equal to nil

### DIFF
--- a/lib/mongoid-simple-tags.rb
+++ b/lib/mongoid-simple-tags.rb
@@ -14,7 +14,7 @@ module Mongoid
 
       module InstanceMethods
         def tag_list=(tags)
-          self.tags = tags.split(",").collect{ |t| t.strip }.delete_if{ |t| t.blank? }
+          self.tags = tags.to_s.split(",").collect{ |t| t.strip }.delete_if{ |t| t.blank? }
         end
 
         def tag_list

--- a/spec/mongoid-simple-tags_spec.rb
+++ b/spec/mongoid-simple-tags_spec.rb
@@ -38,6 +38,12 @@ describe "A Taggable model" do
     user.tags.should_not be_nil
     user.tags.should eql([])
   end
+
+  it "returns an empty array even if tag_list is equal to nil" do
+    user.tag_list = nil
+    user.tags.should_not be_nil
+    user.tags.should eql([])
+  end
 end
 
 


### PR DESCRIPTION
I found a bug when `tag_list` is setted as nil. the instance method `tag_list=` was calling `tags.split` generating an exception: "NoMethodError: undefined method `split' for nil:NilClass".
this pull request contains a commit that fixes the problem :)
