### PR TITLE
running tests with mongoid 3.1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,7 @@ rvm:
   - 1.9.3
 services: mongodb
 script: rake spec
+
+gemfile:
+  - Gemfile
+  - gemfiles/mongoid-3.1.gemfile

--- a/gemfiles/mongoid-3.1.gemfile
+++ b/gemfiles/mongoid-3.1.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'mongoid', '~> 3.1.4'
+
+gemspec path: '../'

--- a/gemfiles/mongoid-3.1.gemfile.lock
+++ b/gemfiles/mongoid-3.1.gemfile.lock
@@ -1,0 +1,45 @@
+PATH
+  remote: /Users/lucasrenan/Gems/mongoid-simple-tags
+  specs:
+    mongoid-simple-tags (0.1.2)
+      json (~> 1.7.7)
+      mongoid (>= 3.0.3)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (3.2.13)
+      activesupport (= 3.2.13)
+      builder (~> 3.0.0)
+    activesupport (3.2.13)
+      i18n (= 0.6.1)
+      multi_json (~> 1.0)
+    builder (3.0.4)
+    diff-lcs (1.1.3)
+    i18n (0.6.1)
+    json (1.7.7)
+    mongoid (3.1.4)
+      activemodel (~> 3.2)
+      moped (~> 1.4)
+      origin (~> 1.0)
+      tzinfo (~> 0.3.22)
+    moped (1.5.0)
+    multi_json (1.7.3)
+    origin (1.1.0)
+    rspec (2.10.0)
+      rspec-core (~> 2.10.0)
+      rspec-expectations (~> 2.10.0)
+      rspec-mocks (~> 2.10.0)
+    rspec-core (2.10.1)
+    rspec-expectations (2.10.0)
+      diff-lcs (~> 1.1.3)
+    rspec-mocks (2.10.1)
+    tzinfo (0.3.37)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  mongoid (~> 3.1.4)
+  mongoid-simple-tags!
+  rspec (~> 2.10.0)

--- a/mongoid-simple-tags.gemspec
+++ b/mongoid-simple-tags.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
   s.add_development_dependency "rspec", "~> 2.10.0"
-  s.add_dependency "mongoid", "~> 3.0.3"
+  s.add_dependency "mongoid", ">= 3.0.3"
   s.add_dependency "json", "~> 1.7.7"
 
 end

--- a/spec/mongoid-simple-tags_spec.rb
+++ b/spec/mongoid-simple-tags_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+puts Mongoid::VERSION
+
 class User
   include Mongoid::Document
   include Mongoid::Document::Taggable


### PR DESCRIPTION
creating another gemfile for travis run tests with mongoid 3.1.x.
this approach is nice to test with many different versions.
