### PR TITLE
Bump json version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source 'https://rubygems.org'
 
 gem 'coveralls', require: false
 # Specify your gem's dependencies in send_grid.gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,41 +1,40 @@
 PATH
   remote: .
   specs:
-    mongoid-simple-tags (0.1.2)
-      json (~> 1.8)
+    mongoid-simple-tags (0.1.3)
+      json (~> 2.3)
       mongoid (>= 3.0.3)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
-    activemodel (3.2.13)
-      activesupport (= 3.2.13)
-      builder (~> 3.0.0)
-    activesupport (3.2.13)
-      i18n (= 0.6.1)
-      multi_json (~> 1.0)
-    builder (3.0.4)
-    colorize (0.5.8)
-    coveralls (0.6.7)
-      colorize
-      multi_json (~> 1.3)
-      rest-client
-      simplecov (>= 0.7)
-      thor
-    diff-lcs (1.2.4)
-    i18n (0.6.1)
-    json (1.8.0)
-    mime-types (1.23)
-    mongoid (3.1.4)
-      activemodel (~> 3.2)
-      moped (~> 1.4)
-      origin (~> 1.0)
-      tzinfo (~> 0.3.22)
-    moped (1.5.0)
-    multi_json (1.7.3)
-    origin (1.1.0)
-    rest-client (1.6.7)
-      mime-types (>= 1.16)
+    activemodel (6.0.3)
+      activesupport (= 6.0.3)
+    activesupport (6.0.3)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2, >= 2.2.2)
+    bson (4.8.2)
+    concurrent-ruby (1.1.6)
+    coveralls (0.8.23)
+      json (>= 1.8, < 3)
+      simplecov (~> 0.16.1)
+      term-ansicolor (~> 1.3)
+      thor (>= 0.19.4, < 2.0)
+      tins (~> 1.6)
+    diff-lcs (1.3)
+    docile (1.3.2)
+    i18n (1.8.2)
+      concurrent-ruby (~> 1.0)
+    json (2.3.0)
+    minitest (5.14.0)
+    mongo (2.12.1)
+      bson (>= 4.8.2, < 5.0.0)
+    mongoid (7.1.1)
+      activemodel (>= 5.1, < 6.1)
+      mongo (>= 2.7.0, < 3.0.0)
     rspec (2.13.0)
       rspec-core (~> 2.13.0)
       rspec-expectations (~> 2.13.0)
@@ -44,12 +43,21 @@ GEM
     rspec-expectations (2.13.0)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.13.1)
-    simplecov (0.7.1)
-      multi_json (~> 1.0)
-      simplecov-html (~> 0.7.1)
-    simplecov-html (0.7.1)
-    thor (0.18.1)
-    tzinfo (0.3.37)
+    simplecov (0.16.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
+    sync (0.5.0)
+    term-ansicolor (1.7.1)
+      tins (~> 1.0)
+    thor (1.0.1)
+    thread_safe (0.3.6)
+    tins (1.24.1)
+      sync
+    tzinfo (1.2.7)
+      thread_safe (~> 0.1)
+    zeitwerk (2.3.0)
 
 PLATFORMS
   ruby
@@ -58,3 +66,6 @@ DEPENDENCIES
   coveralls
   mongoid-simple-tags!
   rspec (~> 2.13.0)
+
+BUNDLED WITH
+   2.1.4

--- a/mongoid-simple-tags.gemspec
+++ b/mongoid-simple-tags.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.add_development_dependency "rspec", "~> 2.13.0"
   s.add_dependency "mongoid", ">= 3.0.3"
-  s.add_dependency "json", "~> 1.8"
+  s.add_dependency "json", "~> 2.3"
 
 end


### PR DESCRIPTION
Bumped the json version to ~> 2.3 as well as switched rubygems source to use https. Also, updated Gemfile.lock to make dependabot happy.

Note: I didn't bump the gem version in this as I leave that up to you.